### PR TITLE
reRun dialog is supposed to populate old dataset names before even showing the dialog using the pre_start_r

### DIFF
--- a/handlers.js
+++ b/handlers.js
@@ -1608,8 +1608,20 @@ module.exports.renderChild = (el) => {
 }
 module.exports.r_before_modal = (modal_id) => {
   var r_commands = JSON.parse($(`#${modal_id}_pre_r`).html())
-  r_on_select(modal_id, r_commands)
-  $(`#${modal_id}`).modal('show');
+  if(modal_id == "reRunOutput"){
+    let temppath = store.get("usertemp")        
+    let bmdname = "rerun.Bmd"
+    let outputFile = path.normalize(path.join(temppath, bmdname)).replace(/\\/g, "/");
+    exportOutput(undefined, outputFile).then(()=>{ //generate Bmd beore showing the dialog
+      r_on_select(modal_id, r_commands)
+      $(`#${modal_id}`).modal('show');
+    });
+  }
+  else {
+    r_on_select(modal_id, r_commands)
+    $(`#${modal_id}`).modal('show');
+  }
+
 }
 
 function renderSelect(element_id, content) {


### PR DESCRIPTION
but pre_start_r also needs a .bmd file in the temp folder. So the code in this commit creates .bmd file in temp before showing the reRunOutput dialog so that pre_start_r can now use the .bmd to generate the list of datasets mentioned in the .bmd (in temp) and populate the old-dataset list in the reRunDialog.