### PR TITLE
columns overwrite feature was not taking the newly created/added vars in the check 

### DIFF
--- a/advancedTextBox.js
+++ b/advancedTextBox.js
@@ -57,9 +57,12 @@ class advancedTextBox extends baseElement {
     canExecute(refToBaseModal) {
         var outer_this = this;
         var value = this.getVal().toString()
+        var dataset = getActiveDataset();
+        var data = store.get(dataset); 
+        const columnNames = data.cols.map(col => col.Name[0]);
         switch (this.overwrite){
             case "variable":
-               if (getActiveVariables().indexOf(value) > -1){
+               if (columnNames.indexOf(value) > -1){
                 var ret = dialog.showMessageBoxSync({type: "question", buttons: ["Ok", "Cancel"], title: t('advTxtBxRulViolationMSgTitle1'), message: `${t('advTxtBxRulViolationMSg1')}: "${outer_this.label}" ${t('advTxtBxRulViolationMSg2')}: ${value}`})
                 if (ret === 0){
                     break

--- a/inputVariable.js
+++ b/inputVariable.js
@@ -70,9 +70,13 @@ class inputVariable extends baseElement {
         let pattern = ""
         var outer_this = this;
         var value = this.getVal()
+        var dataset = getActiveDataset();
+        var data = store.get(dataset); 
+        const columnNames = data.cols.map(col => col.Name[0]);
+        console.log()
         switch (this.overwrite){
             case "variable":
-               if (getActiveVariables().indexOf(value) > -1){
+               if (columnNames.indexOf(value) > -1){
                 var ret = dialog.showMessageBoxSync({type: "question", buttons: ["Ok", "Cancel"], title: t('advTxtBxRulViolationMSgTitle1'), message: `${t('advTxtBxRulViolationMSg1')}: "${outer_this.label}" ${t('advTxtBxRulViolationMSg2')}: ${value}`})
                 if (ret === 0){
                     break


### PR DESCRIPTION
newly added vars were silently getting overwritten. The reason is getActiveVariables() seems to read column names from the DOM and this part of DOM is not refreshed when columns are added/removed from the dataset. And so the overwrite prompt does not show up because new var was never added to DOM. As a fix we now read column names from the store which seems to have latest details about the dataset. So, the overwrite prompt works properly now.