### PR TITLE
while recalling a dialog after Refresh-Dialog-Cache the dynamicallyPopulated flag was lost

### DIFF
--- a/comboBox.js
+++ b/comboBox.js
@@ -40,8 +40,11 @@ class comboBox extends baseElement{
 
     clearContent() {
         var outer_this = this;
-        if (this.dynamicallyPopulated)
+        // console.log(`#${this.id} - Dynamic populated:`,this.dynamicallyPopulated)
+        if ($(`#${this.id}`).attr('dynamicallyPopulated') || this.dynamicallyPopulated)
         {
+            $(`#${this.id}`).attr("dynamicallyPopulated", "true")
+            this.dynamicallyPopulated = true
            // $(`#${this.id}`).empty()
            //clearComboChild(this.id)
            $(`#${this.id}`).children().each(function (index, element) {
@@ -54,7 +57,7 @@ class comboBox extends baseElement{
         else    {
         $(`#${this.id}`).find('option').each(function(index, item){
             if (outer_this.defaults.includes(item.value)){
-                $(`#${outer_this.id}`).siblings("ul").find("a")[index].classList.add("active") ;
+                $(`#${outer_this.id}`)?.siblings("ul")?.find("a")[index]?.classList.add("active") ;
                 item.setAttribute("selected", "selected")
             } else {
                 item.removeAttribute('selected');


### PR DESCRIPTION
…. So we set (in outputTab.js) the flag in DOM (eg Facetrow) and read that here to do the cleaning properly (i.e. clearContent())